### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  basePath: '/canm0re.github.io',
+  images: {
+    unoptimized: true,
+  },
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "copythinking",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "deploy": "next build && next export && touch out/.nojekyll && git add out && git commit -m 'Deploy to GitHub Pages' && git subtree push --prefix out origin gh-pages"
+  },
+  "dependencies": {
+    "@heroicons/react": "^2.2.0",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.469.0",
+    "next": "14.2.16",
+    "react": "^18",
+    "react-dom": "^18",
+    "tailwind-merge": "^2.6.0",
+    "tailwindcss-animate": "^1.0.7"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "eslint": "^8",
+    "eslint-config-next": "14.2.16",
+    "postcss": "^8",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>My GitHub Pages Site</title>
+</head>
+<body>
+  <h1>Welcome to My GitHub Pages Site</h1>
+  <p>This is the entry point for my static site hosted on GitHub Pages.</p>
+</body>
+</html>


### PR DESCRIPTION
Add configuration for GitHub Pages deployment.

* **public/index.html**
  - Add an `index.html` file as the entry point for GitHub Pages.

* **package.json**
  - Add a deployment script for GitHub Pages under the `scripts` section.

* **next.config.mjs**
  - Configure `next.config.mjs` to export the static site correctly.

